### PR TITLE
exercises: Remove shared from tests

### DIFF
--- a/exercises/anagram/source/anagram/AnagramTest.ceylon
+++ b/exercises/anagram/source/anagram/AnagramTest.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test { ... }
 
-shared {[String, {String*}, {String*}]*} cases =>
+{[String, {String*}, {String*}]*} cases =>
   {
     // no matches
     ["diaper", {"hello", "world", "zombies", "pants"}, {}],
@@ -42,6 +42,6 @@ shared {[String, {String*}, {String*}]*} cases =>
 
 test
 parameters(`value cases`)
-shared void testAnagram(String subject, {String*} candidates, {String*} expected) {
+void testAnagram(String subject, {String*} candidates, {String*} expected) {
   assertEquals(sort(anagrams(subject, candidates)), sort(expected));
 }

--- a/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
+++ b/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test { ... }
 
-shared {[String, Boolean]*} cases =>
+{[String, Boolean]*} cases =>
   {
     // paired square brackets
     ["[]", true],
@@ -32,6 +32,6 @@ shared {[String, Boolean]*} cases =>
 
 test
 parameters(`value cases`)
-shared void testBalanced(String brackets, Boolean expected) {
+void testBalanced(String brackets, Boolean expected) {
   assertEquals(balanced(brackets), expected);
 }

--- a/exercises/leap/source/leap/LeapTest.ceylon
+++ b/exercises/leap/source/leap/LeapTest.ceylon
@@ -1,10 +1,10 @@
 import ceylon.test { ... }
 
-shared {[Integer, Boolean]*} cases =>
+{[Integer, Boolean]*} cases =>
   {[2015, false], [2016, true], [2100, false], [2000, true]};
 
 test
 parameters(`value cases`)
-shared void testLeapYear(Integer year, Boolean isLeap) {
+void testLeapYear(Integer year, Boolean isLeap) {
   assertEquals(leapYear(year), isLeap);
 }


### PR DESCRIPTION
The [examples][blog] I looked at had `shared`, but I honestly do not see
why this has to be the case. Maybe it is necessary if the tests are
contained in a test class or something.

In either case, the tests still work without `shared`, so I'm removing
it. Principle of least privilege.

[blog]: https://ceylon-lang.org/blog/2016/02/22/ceylon-test-new-and-noteworthy/