### PR TITLE
Document the need to compile before running tests

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,11 +1,14 @@
 ## Running Ceylon Tests
 
-We run tests with the [ceylon test](https://ceylon-lang.org/documentation/reference/tool/ceylon/subcommands/ceylon-test.html) command.
+Before tests can be run, your code must be compiled via [`ceylon compile`](https://ceylon-lang.org/documentation/current/reference/tool/ceylon/subcommands/ceylon-compile.html).
+
+We run tests with the [`ceylon test`](https://ceylon-lang.org/documentation/reference/tool/ceylon/subcommands/ceylon-test.html) command.
 
 `ceylon test` expects a module name to run the tests on.
 In the Ceylon track, each exercise has just a single module.
+
 Therefore, you can run the tests with:
 
 ```bash
-ceylon test $(basename source/*)
+ceylon compile && ceylon test $(basename source/*)
 ```

--- a/exercises/TRACK_HINTS.md
+++ b/exercises/TRACK_HINTS.md
@@ -1,11 +1,14 @@
 ## Running Ceylon Tests
 
-We run tests with the [ceylon test](https://ceylon-lang.org/documentation/reference/tool/ceylon/subcommands/ceylon-test.html) command.
+Before tests can be run, your code must be compiled via [`ceylon compile`](https://ceylon-lang.org/documentation/current/reference/tool/ceylon/subcommands/ceylon-compile.html).
+
+We run tests with the [`ceylon test`](https://ceylon-lang.org/documentation/reference/tool/ceylon/subcommands/ceylon-test.html) command.
 
 `ceylon test` expects a module name to run the tests on.
 In the Ceylon track, each exercise has just a single module.
+
 Therefore, you can run the tests with:
 
 ```bash
-ceylon test $(basename source/*)
+ceylon compile && ceylon test $(basename source/*)
 ```


### PR DESCRIPTION
If you follow the "Running the Tests" instructions verbatim, the tests will not run because the code hasn't been compiled yet. The proper way to run tests is `ceylon compile && ceylon test $(basename source/*)`.