### PR TITLE
Comment all tests with their x-common version

### DIFF
--- a/exercises/anagram/source/anagram/AnagramTest.ceylon
+++ b/exercises/anagram/source/anagram/AnagramTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {[String, {String*}, {String*}]*} cases => {
   // no matches
   ["diaper", {"hello", "world", "zombies", "pants"}, {}],

--- a/exercises/anagram/source/anagram/AnagramTest.ceylon
+++ b/exercises/anagram/source/anagram/AnagramTest.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test { ... }
 
-// Tests adapted from x-common version 1.0.0
+// Tests adapted from x-common version 1.0.1
 {[String, {String*}, {String*}]*} cases => {
   // no matches
   ["diaper", {"hello", "world", "zombies", "pants"}, {}],
@@ -8,13 +8,13 @@ import ceylon.test { ... }
   ["ant", {"tan", "stand", "at"}, {"tan"}],
   // does not detect false positives
   ["galea", {"eagle"}, {}],
-  // detects multiple anagrams
+  // detects two anagrams
   ["master", {"stream", "pigeon", "maters"}, {"stream", "maters"}],
   // does not detect anagram subsets
   ["good", {"dog", "goody"}, {}],
   // detects anagram
   ["listen", {"enlists", "google", "inlets", "banana"}, {"inlets"}],
-  // detects multiple anagrams
+  // detects three anagrams
   [
     "allergy",
     {"gallery", "ballerina", "regally", "clergy", "largely", "leading"},

--- a/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
+++ b/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {[String, Boolean]*} cases => {
   // paired square brackets
   ["[]", true],

--- a/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
+++ b/exercises/bracket-push/source/bracketpush/BracketsTest.ceylon
@@ -1,6 +1,6 @@
 import ceylon.test { ... }
 
-// Tests adapted from x-common version 1.0.0
+// Tests adapted from x-common version 1.1.0
 {[String, Boolean]*} cases => {
   // paired square brackets
   ["[]", true],
@@ -10,6 +10,8 @@ import ceylon.test { ... }
   ["[[", false],
   // wrong ordered brackets
   ["}{", false],
+  // wrong closing bracket
+  ["{]", false],
   // paired with whitespace
   ["{ }", true],
   // simple nested brackets

--- a/exercises/hamming/source/hamming/HammingTest.ceylon
+++ b/exercises/hamming/source/hamming/HammingTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {[String, String, Integer?]*} cases => {
   ["A", "A", 0],
   ["GGACTGA", "GGACTGA", 0],

--- a/exercises/hamming/source/hamming/HammingTest.ceylon
+++ b/exercises/hamming/source/hamming/HammingTest.ceylon
@@ -2,20 +2,35 @@ import ceylon.test { ... }
 
 // Tests adapted from x-common version 1.0.0
 {[String, String, Integer?]*} cases => {
+  // identical strands
   ["A", "A", 0],
+  // long identical strands
   ["GGACTGA", "GGACTGA", 0],
+  // complete distance in single nucleotide strands
   ["A", "G", 1],
+  // complete distance in small strands
   ["AG", "CT", 2],
+  // small distance in small strands
   ["AT", "CT", 1],
+  // small distance
   ["GGACG", "GGTCG", 1],
+  // small distance in long strands
   ["ACCAGGG", "ACTATGG", 2],
+  // non-unique character in first strand
   ["AGA", "AGG", 1],
+  // non-unique character in second strand
   ["AGG", "AGA", 1],
+  // same nucleotides in different positions
   ["TAG", "GAT", 2],
+  // large distance
   ["GATACA", "GCATAA", 4],
+  // large distance in off-by-one strand
   ["GGACGGATTCTG", "AGGACGGATTCT", 9],
+  // empty strands
   ["", "", 0],
+  // disallow first strand longer
   ["AATG", "AAA", null],
+  // disallow second strand longer
   ["ATA", "AGTG", null]
 };
 

--- a/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
+++ b/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
@@ -2,20 +2,35 @@ import ceylon.test { ... }
 
 // Tests adapted from x-common version 1.0.0
 {[String, Integer, Integer?]*} cases => {
+  // finds the largest product if span equals length
   ["29", 2, 18],
+  // can find the largest product of 2 with numbers in order
   ["0123456789", 2, 72],
+  // can find the largest product of 2
   ["576802143", 2, 48],
+  // can find the largest product of 3 with numbers in order
   ["0123456789", 3, 504],
+  // can find the largest product of 3
   ["1027839564", 3, 270],
+  // can find the largest product of 5 with numbers in order
   ["0123456789", 5, 15120],
+  // can get the largest product of a big number
   ["73167176531330624919225119674426574742355349194934", 6, 23520],
+  // reports zero if the only digits are zero
   ["0000", 2, 0],
+  // reports zero if all spans include zero
   ["99099", 3, 0],
+  // rejects span longer than string length
   ["123", 4, null],
+  // reports 1 for empty string and empty product (0 span)
   ["", 0, 1],
+  // reports 1 for nonempty string and empty product (0 span)
   ["123", 0, 1],
+  // rejects empty string and nonzero span
   ["", 1, null],
+  // rejects invalid character in digits
   ["1234a5", 2, null],
+  // rejects negative span
   ["12345", -1, null]
 };
 

--- a/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
+++ b/exercises/largest-series-product/source/largestseriesproduct/SeriesTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {[String, Integer, Integer?]*} cases => {
   ["29", 2, 18],
   ["0123456789", 2, 72],

--- a/exercises/leap/source/leap/LeapTest.ceylon
+++ b/exercises/leap/source/leap/LeapTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {[Integer, Boolean]*} cases =>
   {[2015, false], [2016, true], [2100, false], [2000, true]};
 

--- a/exercises/react/source/react/ReactorTest.ceylon
+++ b/exercises/react/source/react/ReactorTest.ceylon
@@ -1,5 +1,7 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
+
 test
 void inputCellsHaveValue() {
   value r = Reactor<Integer>();

--- a/exercises/sieve/source/sieve/SieveTest.ceylon
+++ b/exercises/sieve/source/sieve/SieveTest.ceylon
@@ -1,5 +1,6 @@
 import ceylon.test { ... }
 
+// Tests adapted from x-common version 1.0.0
 {Integer*} cases => {1, 2, 10, 13, 1000};
 
 [Integer+] primes1000 = [


### PR DESCRIPTION
All canonical-data.json comply with https://github.com/exercism/x-common/issues/625.
They are versioned according to https://github.com/exercism/x-common/issues/673.

We can use this to tell whether our tests are out of date.